### PR TITLE
Add Dockerfile and build/launch script to easily run documentation system in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.9.23-slim
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+ENTRYPOINT ["python", "run.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  doc:
+    image: workflows-doc:latest
+    build:
+      context: .
+    ports:
+      - "8000:8000"

--- a/run-as-docker-container.sh
+++ b/run-as-docker-container.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+docker compose up -d --build
+
+# Vérifie le système d'exploitation
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS
+  open -a Safari http://localhost:8000
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+  # Windows (utilisation de commandes spécifiques à Windows)
+  start chrome http://localhost:8000
+else
+  # Système d'exploitation par défaut pour le navigateur local
+  echo "Le navigateur local n'est pas supporté sur ce système."
+fi


### PR DESCRIPTION
- What: I propose a run-as-docker.sh script which will automatically build the image, run the container and attempt to open the browser.
- Why: makes it easy to run the documentation system without touching local Python's configuration or creating a Python virtual env.
- Status: tested on macOS only as I do not have any Windows host.