### PR TITLE
Fix Windows crash caused by banner emoji

### DIFF
--- a/run.py
+++ b/run.py
@@ -105,6 +105,7 @@ def start_server(host: str = "127.0.0.1", port: int = 8000, reload: bool = False
 
 def main():
     """Main entry point with command line arguments."""
+    sys.stdout.reconfigure(encoding='utf-8')
     parser = argparse.ArgumentParser(
         description="N8N Workflows Search Engine",
         formatter_class=argparse.RawDescriptionHelpFormatter,


### PR DESCRIPTION
Hi 👋

I noticed the project was crashing on Windows because the rocket emoji (🚀) in
the banner couldn't be encoded with the default terminal settings.

This PR updates the banner print so it works on Windows too.  
Now the app runs without errors, and the banner still looks fine where emojis are supported.

Thanks!
