### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,15 +22,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache Python dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -92,7 +92,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
@@ -127,7 +127,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -152,7 +152,7 @@ jobs:
           type=sha,prefix=sha-
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         platforms: linux/amd64,linux/arm64
@@ -171,7 +171,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Deploy to staging
       run: |
@@ -188,7 +188,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Deploy to production
       run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -49,10 +49,10 @@ jobs:
           python scripts/generate_search_index.py
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './docs'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Build Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         load: true
@@ -118,7 +118,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -129,7 +129,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Build multi-platform image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload docs directory
           path: './docs'

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/deploy-pages.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/deploy-pages.yml`
- Updated `actions/upload-pages-artifact` from `v3` to `v4` in `.github/workflows/deploy-pages.yml`
- Updated `actions/upload-pages-artifact` from `v3` to `v4` in `.github/workflows/pages-deploy.yml`
- Updated `docker/build-push-action` from `v5` to `v6` in `.github/workflows/ci-cd.yml`
- Updated `actions/configure-pages` from `v4` to `v5` in `.github/workflows/deploy-pages.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docker.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/update-readme.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/pages-deploy.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/update-readme.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci-cd.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/ci-cd.yml`
- Updated `actions/cache` from `v3` to `v5` in `.github/workflows/ci-cd.yml`
- Updated `docker/build-push-action` from `v5` to `v6` in `.github/workflows/docker.yml`
