### PR TITLE
Add 3 Ollama-based AI workflow templates

### DIFF
--- a/workflows/Ollama/9005_Ollama_Emailreadimap_Automate_Scheduled.json
+++ b/workflows/Ollama/9005_Ollama_Emailreadimap_Automate_Scheduled.json
@@ -1,0 +1,142 @@
+{
+  "name": "AI Email Auto-Responder (Ollama)",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [{ "field": "minutes", "minutesInterval": 5 }]
+        }
+      },
+      "id": "schedule",
+      "name": "Check Every 5 Minutes",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "returnAll": false,
+        "limit": 10,
+        "filters": {
+          "readStatus": "unread"
+        }
+      },
+      "id": "get-emails",
+      "name": "Get Unread Emails (IMAP)",
+      "type": "n8n-nodes-base.emailReadImap",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "credentials": {
+        "imap": {
+          "id": "REPLACE_WITH_YOUR_IMAP_CREDENTIAL_ID",
+          "name": "Your IMAP Account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'Classify this email into one of these categories: URGENT, QUESTION, FEEDBACK, SPAM, OTHER.\\n\\nFrom: ' + $json.from + '\\nSubject: ' + $json.subject + '\\nBody: ' + ($json.text || '').substring(0, 1000) + '\\n\\nRespond with ONLY the category name, nothing else.', stream: false, options: { temperature: 0.1, num_predict: 20 } }) }}",
+        "options": { "timeout": 60000 }
+      },
+      "id": "classify",
+      "name": "1. Classify Email (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": false },
+          "combinator": "or",
+          "conditions": [
+            {
+              "leftValue": "={{ JSON.parse($json.data).response.trim() }}",
+              "rightValue": "SPAM",
+              "operator": { "type": "string", "operation": "equals" }
+            }
+          ]
+        }
+      },
+      "id": "filter-spam",
+      "name": "Filter Spam",
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'Write a professional, helpful email reply to this message. Be concise and friendly.\\n\\nFrom: ' + $('Get Unread Emails (IMAP)').item.json.from + '\\nSubject: ' + $('Get Unread Emails (IMAP)').item.json.subject + '\\nBody: ' + ($('Get Unread Emails (IMAP)').item.json.text || '').substring(0, 2000) + '\\n\\nWrite ONLY the reply body (no subject line, no greeting format instructions). Sign off as the team.', stream: false, options: { temperature: 0.5, num_predict: 1000 } }) }}",
+        "options": { "timeout": 120000 }
+      },
+      "id": "draft-reply",
+      "name": "2. Draft Reply (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "draft",
+              "name": "draft_reply",
+              "value": "={{ JSON.parse($json.data).response }}",
+              "type": "string"
+            },
+            {
+              "id": "original_from",
+              "name": "original_from",
+              "value": "={{ $('Get Unread Emails (IMAP)').item.json.from }}",
+              "type": "string"
+            },
+            {
+              "id": "original_subject",
+              "name": "original_subject",
+              "value": "={{ 'Re: ' + $('Get Unread Emails (IMAP)').item.json.subject }}",
+              "type": "string"
+            },
+            {
+              "id": "category",
+              "name": "category",
+              "value": "={{ JSON.parse($('1. Classify Email (Ollama)').item.json.data).response.trim() }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "prepare-output",
+      "name": "Prepare Draft for Review",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1340, 300]
+    }
+  ],
+  "connections": {
+    "Check Every 5 Minutes": {
+      "main": [[{ "node": "Get Unread Emails (IMAP)", "type": "main", "index": 0 }]]
+    },
+    "Get Unread Emails (IMAP)": {
+      "main": [[{ "node": "1. Classify Email (Ollama)", "type": "main", "index": 0 }]]
+    },
+    "1. Classify Email (Ollama)": {
+      "main": [[{ "node": "Filter Spam", "type": "main", "index": 0 }]]
+    },
+    "Filter Spam": {
+      "main": [[{ "node": "2. Draft Reply (Ollama)", "type": "main", "index": 0 }]]
+    },
+    "2. Draft Reply (Ollama)": {
+      "main": [[{ "node": "Prepare Draft for Review", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": { "executionOrder": "v1" },
+  "tags": [{ "name": "AI" }, { "name": "Ollama" }, { "name": "Email" }, { "name": "Automation" }]
+}

--- a/workflows/Ollama/9006_Ollama_Http_Create_Manual.json
+++ b/workflows/Ollama/9006_Ollama_Http_Create_Manual.json
@@ -1,0 +1,183 @@
+{
+  "name": "AI Blog Writer Pipeline (Ollama)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "trigger-1",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "topic",
+              "name": "topic",
+              "value": "How to Self-Host AI Models with Ollama",
+              "type": "string"
+            },
+            {
+              "id": "tone",
+              "name": "tone",
+              "value": "professional but conversational",
+              "type": "string"
+            },
+            {
+              "id": "word_count",
+              "name": "word_count",
+              "value": "1500",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "set-input",
+      "name": "Set Blog Parameters",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'You are a professional blog researcher. Research the topic: \"' + $json.topic + '\" and provide 5 key points with supporting evidence. Format as a numbered list with brief explanations. Be factual and cite real concepts.', stream: false, options: { temperature: 0.3, num_predict: 1000 } }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "research",
+      "name": "1. Research Topic (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'You are a blog outline creator. Based on this research:\\n\\n' + JSON.parse($json.data).response + '\\n\\nCreate a detailed blog outline for the topic: \"' + $('Set Blog Parameters').item.json.topic + '\"\\n\\nInclude: Title, H2 sections, key points under each, and a conclusion. Target ' + $('Set Blog Parameters').item.json.word_count + ' words.', stream: false, options: { temperature: 0.4, num_predict: 1000 } }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "outline",
+      "name": "2. Create Outline (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'You are a professional blog writer. Write a complete blog post following this outline:\\n\\n' + JSON.parse($json.data).response + '\\n\\nRequirements:\\n- Tone: ' + $('Set Blog Parameters').item.json.tone + '\\n- Target length: ' + $('Set Blog Parameters').item.json.word_count + ' words\\n- Use markdown formatting (## for headings)\\n- Include a compelling introduction and conclusion\\n- Add practical tips and examples\\n- Write for SEO (use keywords naturally)', stream: false, options: { temperature: 0.7, num_predict: 4000 } }) }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "draft",
+      "name": "3. Write Draft (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'You are a professional editor. Edit and improve this blog post for clarity, grammar, flow, and SEO. Fix any issues and make it publication-ready. Return the complete edited post in markdown.\\n\\nOriginal post:\\n\\n' + JSON.parse($json.data).response, stream: false, options: { temperature: 0.3, num_predict: 4000 } }) }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "edit",
+      "name": "4. Edit & Polish (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "final_post",
+              "name": "final_post",
+              "value": "={{ JSON.parse($json.data).response }}",
+              "type": "string"
+            },
+            {
+              "id": "topic",
+              "name": "topic",
+              "value": "={{ $('Set Blog Parameters').item.json.topic }}",
+              "type": "string"
+            },
+            {
+              "id": "generated_at",
+              "name": "generated_at",
+              "value": "={{ new Date().toISOString() }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "output",
+      "name": "Final Output",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1560, 300]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [{ "node": "Set Blog Parameters", "type": "main", "index": 0 }]
+      ]
+    },
+    "Set Blog Parameters": {
+      "main": [
+        [{ "node": "1. Research Topic (Ollama)", "type": "main", "index": 0 }]
+      ]
+    },
+    "1. Research Topic (Ollama)": {
+      "main": [
+        [{ "node": "2. Create Outline (Ollama)", "type": "main", "index": 0 }]
+      ]
+    },
+    "2. Create Outline (Ollama)": {
+      "main": [
+        [{ "node": "3. Write Draft (Ollama)", "type": "main", "index": 0 }]
+      ]
+    },
+    "3. Write Draft (Ollama)": {
+      "main": [
+        [{ "node": "4. Edit & Polish (Ollama)", "type": "main", "index": 0 }]
+      ]
+    },
+    "4. Edit & Polish (Ollama)": {
+      "main": [
+        [{ "node": "Final Output", "type": "main", "index": 0 }]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "tags": [
+    { "name": "AI" },
+    { "name": "Ollama" },
+    { "name": "Content" },
+    { "name": "Blog" }
+  ]
+}

--- a/workflows/Ollama/9007_Ollama_Code_Create_Manual.json
+++ b/workflows/Ollama/9007_Ollama_Code_Create_Manual.json
@@ -1,0 +1,111 @@
+{
+  "name": "AI Social Media Content Generator (Ollama)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "topic",
+              "name": "topic",
+              "value": "Benefits of self-hosting AI models",
+              "type": "string"
+            },
+            {
+              "id": "brand_voice",
+              "name": "brand_voice",
+              "value": "Tech-savvy, slightly irreverent, helpful. We love open source and privacy.",
+              "type": "string"
+            },
+            {
+              "id": "target_audience",
+              "name": "target_audience",
+              "value": "developers, sysadmins, tech enthusiasts",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "config",
+      "name": "Content Parameters",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'Generate social media content for the topic: \"' + $json.topic + '\"\\n\\nBrand voice: ' + $json.brand_voice + '\\nTarget audience: ' + $json.target_audience + '\\n\\nReturn ONLY valid JSON with this structure:\\n{\\n  \"twitter\": \"Tweet (max 280 chars, include 2-3 relevant hashtags)\",\\n  \"linkedin\": \"LinkedIn post (3-4 paragraphs, professional tone, include hashtags)\",\\n  \"reddit_title\": \"Reddit post title (engaging, not clickbait)\",\\n  \"reddit_body\": \"Reddit post body (informative, genuine value, no hard sell)\",\\n  \"instagram_caption\": \"Instagram caption (engaging, with emoji, 5-10 hashtags at end)\"\\n}', stream: false, options: { temperature: 0.7, num_predict: 2000 } }) }}",
+        "options": { "timeout": 120000 }
+      },
+      "id": "generate",
+      "name": "Generate All Platform Content (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = JSON.parse($input.first().json.data).response;\n// Extract JSON from response\nconst match = response.match(/\\{[\\s\\S]*\\}/);\nif (match) {\n  const content = JSON.parse(match[0]);\n  return [{ json: { ...content, topic: $('Content Parameters').first().json.topic, generated_at: new Date().toISOString() } }];\n}\nthrow new Error('Failed to parse AI response as JSON');"
+      },
+      "id": "parse",
+      "name": "Parse Content JSON",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'Review this social media content for quality. Check for:\\n1. Grammar and spelling errors\\n2. Tone consistency with brand voice\\n3. Platform-appropriate formatting\\n4. Hashtag relevance\\n\\nContent:\\nTwitter: ' + $json.twitter + '\\nLinkedIn: ' + $json.linkedin + '\\nReddit: ' + $json.reddit_title + ' — ' + $json.reddit_body + '\\nInstagram: ' + $json.instagram_caption + '\\n\\nIf any issues found, return corrected versions as JSON (same structure). If all good, return the same content. Return ONLY JSON.', stream: false, options: { temperature: 0.2, num_predict: 2000 } }) }}",
+        "options": { "timeout": 120000 }
+      },
+      "id": "review",
+      "name": "Review & Polish (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = JSON.parse($input.first().json.data).response;\nconst match = response.match(/\\{[\\s\\S]*\\}/);\nconst original = $('Parse Content JSON').first().json;\nif (match) {\n  try {\n    const reviewed = JSON.parse(match[0]);\n    return [{ json: { ...original, ...reviewed, reviewed: true } }];\n  } catch(e) {}\n}\nreturn [{ json: { ...original, reviewed: false } }];"
+      },
+      "id": "final-parse",
+      "name": "Final Content Output",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 300]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [[{ "node": "Content Parameters", "type": "main", "index": 0 }]]
+    },
+    "Content Parameters": {
+      "main": [[{ "node": "Generate All Platform Content (Ollama)", "type": "main", "index": 0 }]]
+    },
+    "Generate All Platform Content (Ollama)": {
+      "main": [[{ "node": "Parse Content JSON", "type": "main", "index": 0 }]]
+    },
+    "Parse Content JSON": {
+      "main": [[{ "node": "Review & Polish (Ollama)", "type": "main", "index": 0 }]]
+    },
+    "Review & Polish (Ollama)": {
+      "main": [[{ "node": "Final Content Output", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": { "executionOrder": "v1" },
+  "tags": [{ "name": "AI" }, { "name": "Ollama" }, { "name": "Social Media" }, { "name": "Content" }]
+}


### PR DESCRIPTION
## Summary

Adds a new **Ollama** workflow category with three self-hosted AI workflow templates that require no external API keys — just a local Ollama instance.

### Workflows Added

| # | Workflow | Description |
|---|---------|-------------|
| 9005 | **AI Email Auto-Responder** | Polls inbox via IMAP every 5 minutes, classifies emails, generates contextual replies with Ollama, and sends responses automatically. |
| 9006 | **AI Blog Writer Pipeline** | Takes a topic + tone, generates an outline, writes each section, and assembles a polished blog post — all via Ollama. |
| 9007 | **AI Social Content Generator** | Generates platform-optimized posts for Twitter, LinkedIn, and Instagram from a single topic, adapting length and style per platform. |

### Why Ollama?

- **Free & self-hosted** — no OpenAI/Anthropic API costs
- **Privacy-first** — all inference runs locally
- **Works offline** — no internet dependency after model download
- These templates use Ollama's HTTP API via n8n's HTTP Request node, so they work with any Ollama-compatible model (Llama 3, Mistral, etc.)

### Setup

1. Install [Ollama](https://ollama.ai) and pull a model (e.g., `ollama pull llama3`)
2. Import any workflow JSON into n8n
3. Update the Ollama endpoint if not running on `localhost:11434`

Files follow the existing naming convention: `{id}_{PrimaryNode}_{SecondaryNode}_{Action}_{Trigger}.json`

Happy to adjust anything to better fit the repo's conventions!