### PR TITLE
Add Posta social media automation workflows (4 templates)

### DIFF
--- a/workflows/Posta/Posta_Blog_to_LinkedIn_Carousel_Triggered.json
+++ b/workflows/Posta/Posta_Blog_to_LinkedIn_Carousel_Triggered.json
@@ -1,0 +1,729 @@
+{
+  "name": "Create LinkedIn carousel post from blog post",
+  "nodes": [
+    {
+      "parameters": {},
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -240,
+        112
+      ],
+      "id": "905cdfa8-0d33-44c4-9f75-90e438207355",
+      "name": "When clicking ‘Execute workflow’"
+    },
+    {
+      "parameters": {
+        "url": "https://getposta.app/feed.xml",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.rssFeedRead",
+      "typeVersion": 1.2,
+      "position": [
+        64,
+        16
+      ],
+      "id": "db75812c-7715-44ff-adec-97e5b889358f",
+      "name": "RSS Read",
+      "notes": "Add the link to the RSS feed"
+    },
+    {
+      "parameters": {
+        "content": "Add the link to the RSS feed, in this example we use the blog feed from getposta.app (https://getposta.app/feed.xml)",
+        "height": 352,
+        "width": 160
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        32,
+        -192
+      ],
+      "id": "7fde9dfa-159b-453e-8e62-8afcf724e2b3",
+      "name": "Sticky Note"
+    },
+    {
+      "parameters": {
+        "socialAccountIds": "35",
+        "caption": "={{ $('Parse slides JSON').item.json.caption }}{{ $('Latest post').item.json.link }}",
+        "additionalFields": {
+          "hashtags": "={{ $('Parse slides JSON').item.json.tags }}",
+          "mediaIds": "={{ $json.media_id }}"
+        },
+        "platformConfigurations": {
+          "linkedin": {
+            "documentTitle": "={{ $json.title }}"
+          }
+        }
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        3264,
+        -96
+      ],
+      "id": "ae315a5d-b1c9-415b-b38b-5897bbf1b6df",
+      "name": "Create a post",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "socialAccount"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        304,
+        256
+      ],
+      "id": "d92a5744-c0e1-4619-b336-c407bb27a7f1",
+      "name": "Get many social accounts",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "You need to tell the workflow where to post - call this to get a list of connected social accounts. You need to take the id value and feed into the next step. IDs are preserved in Posta until you delete the connected account. To sign-up and connect social accounts, visit https://www.getposta.app (14 days free, no credit card required)",
+        "height": 240,
+        "color": 3
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        240,
+        448
+      ],
+      "id": "6898e38d-92d5-4acc-a146-d7d702051283",
+      "name": "Sticky Note1"
+    },
+    {
+      "parameters": {
+        "content": "You need a token to use the Posta functions. Get one at https://www.getposta.app (14 days free, no credit card required)",
+        "height": 128,
+        "color": 3
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -368,
+        -64
+      ],
+      "id": "7bc18f20-0b43-444e-93e1-6be6b55a7f4e",
+      "name": "Sticky Note2"
+    },
+    {
+      "parameters": {
+        "content": "## Blog post → LinkedIn carousel\n\n**Who it's for:** creators who want high-engagement LinkedIn carousels from their articles without designing slides.\n**What it does:** summarizes a new blog post into a 5-slide carousel PDF — AI text over AI backgrounds — and posts it to LinkedIn via Posta.\n\n**How it works:**\n1. Read the blog feed and pick the latest post.\n2. DeepSeek writes 5 slides (title + body); split them out.\n3. fal.ai generates a background per slide; upload each to Posta.\n4. Posta composites the text and builds the PDF; create the LinkedIn post.\n\n**Setup:** add Posta (Professional plan), DeepSeek, and fal.ai credentials. Sign up at https://www.getposta.app (14 days free, no credit card).",
+        "height": 320,
+        "color": 5
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -368,
+        -368
+      ],
+      "id": "31efd7a4-96cb-4f42-95c8-3a4305792b44",
+      "name": "Sticky Note3"
+    },
+    {
+      "parameters": {
+        "content": "In the create post you need to set at least one social account id (from \"get many social accounts\"), caption and optionally tags. For each supported social media account type, you can also set platform specific attributes like visibility etc. You can also add media ids to upload images and videos. Images and videos are scaled by Posta for each platform (9:16 for TikTok for example). Posta uses facial recognition to try to crop media if faces are present. ",
+        "height": 304
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        3200,
+        64
+      ],
+      "id": "335656b0-271f-4092-b077-7b429038a38b",
+      "name": "Sticky Note4"
+    },
+    {
+      "parameters": {
+        "resource": "media"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        2480,
+        -96
+      ],
+      "id": "c77ec554-304d-41c5-b1b0-315d323b43f1",
+      "name": "Upload media",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.images[0].url }}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "file"
+            }
+          }
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        2208,
+        -96
+      ],
+      "id": "6589116c-f42b-4354-8e0f-e358b133d62c",
+      "name": "Download generated background"
+    },
+    {
+      "parameters": {
+        "content": "Add the URL for the image. Then options -> response -> then \"response format -> file\" and put the output in field \"data\". This loads the image into the \"data\" field for further processing. ",
+        "height": 512
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2144,
+        -288
+      ],
+      "id": "89031161-66b6-4235-a651-dfcd7a0cd3a2",
+      "name": "Sticky Note5"
+    },
+    {
+      "parameters": {
+        "content": "This upload the contents of the \"data\" field from the precious node to the Posta platform and image processing starts (scaling for the different platforms). This also works for videos.",
+        "height": 512
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2416,
+        -288
+      ],
+      "id": "20d12e43-4028-4881-9271-0e26ad7941bb",
+      "name": "Sticky Note6"
+    },
+    {
+      "parameters": {
+        "jsCode": "const items = $input.all();\n  items.sort((a, b) =>\n    new Date(b.json.isoDate || b.json.pubDate).getTime() -\n    new Date(a.json.isoDate || a.json.pubDate).getTime()\n  );\n  return items.length ? [items[0]] : [];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        272,
+        16
+      ],
+      "id": "4798dbe5-598c-4075-a770-1c6f4ed68685",
+      "name": "Latest post"
+    },
+    {
+      "parameters": {
+        "content": "Select the latest post",
+        "height": 352,
+        "width": 160
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        240,
+        -192
+      ],
+      "id": "f765dde3-24e7-4339-b0ef-ddf4ba98e6f5",
+      "name": "Sticky Note10"
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "=Turn the article below into a 5-slide LinkedIn carousel.\n\n  Rules:\n  - Exactly 5 slides.\n  - Slide 1 = a scroll-stopping hook. Slides 2–4 = the key takeaways (one idea per slide). Slide 5 = a clear call to action.\n  - Each slide has a short \"title\" (max ~6 words) and a \"body\" of 2–3 punchy lines (max ~360 characters). Plain text, no markdown, no emojis in the title.\n   Each slide also has an \"image_prompt\": a VERY short phrase describing one or two soft simple shapes and 2 muted colors on a deep background — e.g. \"a soft coral orb on\n  deep plum\" or \"two gentle mauve shapes on deep indigo\". Keep colors muted and gentle, never neon or harsh. Shapes and colors only — no scenes, no nature, no people, no text.\n  - Also write 3–5 relevant \"tags\" (hashtag words, WITHOUT the # symbol) and a 1–2 sentence LinkedIn \"caption\" to accompany the carousel.\n  - Base everything strictly on the article — do not invent facts, names, or numbers.\n\n  Return ONLY raw minified JSON — no markdown, no code fences, no commentary:\n  {\"caption\":\"...\",\"tags\":[\"...\",\"...\"],\"slides\":[{\"title\":\"...\",\"body\":\"...\",\"image_prompt\":\"...\"}]}\n\n  ARTICLE TITLE: {{ $json.title }}\n\n  ARTICLE:\n  {{ $json[\"content:encoded\"] }}",
+        "messages": {
+          "messageValues": [
+            {
+              "message": "You are an expert LinkedIn carousel copywriter. You always return valid minified JSON and nothing else."
+            }
+          ]
+        },
+        "batching": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.chainLlm",
+      "typeVersion": 1.9,
+      "position": [
+        576,
+        -176
+      ],
+      "id": "7d069dce-b703-4a42-ac33-0598d865e1e0",
+      "name": "Basic LLM Chain"
+    },
+    {
+      "parameters": {
+        "model": "deepseek-v4-pro",
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.lmChatDeepSeek",
+      "typeVersion": 1,
+      "position": [
+        576,
+        80
+      ],
+      "id": "9335ef86-74f8-492f-84eb-6c4f25bc05c5",
+      "name": "DeepSeek Chat Model",
+      "credentials": {
+        "deepSeekApi": {
+          "name": "DeepSeek account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "Let the LLM summarize and create text for 5 slides. If you want fewer, change the prompt accordingly.",
+        "height": 512,
+        "width": 320
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        528,
+        -288
+      ],
+      "id": "74b3e5bd-33d3-4b35-886f-be58d6483ca9",
+      "name": "Sticky Note11"
+    },
+    {
+      "parameters": {
+        "fieldToSplitOut": "slides",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.splitOut",
+      "typeVersion": 1,
+      "position": [
+        1216,
+        -176
+      ],
+      "id": "0ef31a8f-a23e-452f-8a44-bdb887a57057",
+      "name": "Split into slides"
+    },
+    {
+      "parameters": {
+        "jsCode": "// \"Run Once for Each Item\" — or All Items\n  const raw = String($json.text ?? $json.output ?? '');\n  const m = raw.match(/```(?:json)?\\s*([\\s\\S]*?)```/i);\n  const jsonStr = m ? m[1] : raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1);\n  return [{ json: JSON.parse(jsonStr.trim()) }];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        928,
+        -176
+      ],
+      "id": "3a3361fd-dfd8-4b57-96e4-648e8f0d6cb7",
+      "name": "Parse slides JSON"
+    },
+    {
+      "parameters": {
+        "content": "Parse the response into something more useful",
+        "height": 512,
+        "width": 256
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        880,
+        -288
+      ],
+      "id": "0c1f1c50-d884-482f-b98c-62201f4e0409",
+      "name": "Sticky Note12"
+    },
+    {
+      "parameters": {
+        "content": "Split out to 5 title / body items, one for each slide.",
+        "height": 512
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1152,
+        -288
+      ],
+      "id": "d275d34a-fcda-4c13-a19f-4fe1196de800",
+      "name": "Sticky Note13"
+    },
+    {
+      "parameters": {
+        "model": {
+          "__rl": true,
+          "value": "fal-ai/flux/schnell",
+          "mode": "list",
+          "cachedResultName": "FLUX.1 [schnell] [text-to-image]"
+        },
+        "modelParameters": {
+          "parameters": [
+            {
+              "parameter": "image_size",
+              "value": "square_hd"
+            },
+            {
+              "parameter": "prompt",
+              "value": "={{ $json.theme_color }} smooth gradient, minimal flat graphic background, a couple of subtle soft tonal shapes in the same color slightly lighter, clean modern,\n  lots of plain empty space, professional, no text"
+            }
+          ]
+        },
+        "options": {
+          "waitForCompletion": true,
+          "pollInterval": 5,
+          "maxWaitTime": 600
+        }
+      },
+      "type": "@fal-ai/n8n-nodes-fal.falAi",
+      "typeVersion": 1,
+      "position": [
+        1936,
+        -176
+      ],
+      "id": "d037dbcb-88e9-4daf-b655-7b63bdb29a6e",
+      "name": "Generate media using AI model",
+      "credentials": {
+        "falAiApi": {
+          "name": "fal.ai account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "Generate some background images. Recraft V3.",
+        "height": 512,
+        "width": 256
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1856,
+        -288
+      ],
+      "id": "0eb79ec8-c34b-420f-b3c3-91071ef18e06",
+      "name": "Sticky Note14"
+    },
+    {
+      "parameters": {
+        "jsCode": "\n  const text = $('Split into slides').all();  \n\n  return [{\n    json: {\n      slides: $input.all().map((up, i) => ({\n        media_id: up.json.media?.id ?? up.json.media_id ?? up.json.id,\n        title: text[i].json.title,\n        body: text[i].json.body,\n      })),\n    },\n  }];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2736,
+        -96
+      ],
+      "id": "54b17e8d-38c1-4fa8-9bf7-a59ce2611c7e",
+      "name": "Re-assemble slides"
+    },
+    {
+      "parameters": {
+        "content": "Re-assemble the slides array, now we have image, title, body",
+        "height": 512
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2672,
+        -288
+      ],
+      "id": "acdf22e4-fe38-489f-a4f2-cd47bdc7a156",
+      "name": "Sticky Note15"
+    },
+    {
+      "parameters": {
+        "resource": "media",
+        "operation": "generateTextCarouselPdf",
+        "slides": "={{ JSON.stringify($json.slides.map(s => ({ media_id: s.media_id, title: s.title, body: s.body }))) }}",
+        "logoMediaId": "3cd2fd96-1281-4742-b8e8-f6a65959b3d5"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        2992,
+        -96
+      ],
+      "id": "b07ff25d-45b4-4fb5-9c87-6c58d21aafab",
+      "name": "Generate text carousel PDF",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1aa8531-76b0-46b0-a086-0bd10267f8ca",
+              "name": "theme_color",
+              "value": "dark blue",
+              "type": "string"
+            },
+            {
+              "id": "6f3c8682-8438-4d6f-9a6c-b0c7bc484421",
+              "name": "title",
+              "value": "={{ $json.title }}",
+              "type": "string"
+            },
+            {
+              "id": "838aea94-15c5-4e78-9de5-9a71aea42079",
+              "name": "image_prompt",
+              "value": "={{ $json.image_prompt }}",
+              "type": "string"
+            },
+            {
+              "id": "4741cf92-5741-4db8-abd3-e5dff31ad658",
+              "name": "body",
+              "value": "={{ $json.body }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        1568,
+        -176
+      ],
+      "id": "afaf794a-db70-428c-a24a-ab150a5dd8b6",
+      "name": "theme_color"
+    },
+    {
+      "parameters": {
+        "content": "Set a **theme color** to make sure the slides use the same color scheme",
+        "height": 512,
+        "width": 272
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1488,
+        -288
+      ],
+      "id": "ab6d300d-da22-41ec-b98c-6ad98a08aaa3",
+      "name": "Sticky Note16"
+    },
+    {
+      "parameters": {
+        "content": "Generate the PDF carousel. Note the optional Logo Media ID to set a logo in the slides.",
+        "height": 512
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2928,
+        -288
+      ],
+      "id": "4fc4f6e7-ae0d-4839-b796-3c4262bb3d69",
+      "name": "Sticky Note17"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "When clicking ‘Execute workflow’": {
+      "main": [
+        [
+          {
+            "node": "Get many social accounts",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "RSS Read",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "RSS Read": {
+      "main": [
+        [
+          {
+            "node": "Latest post",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download generated background": {
+      "main": [
+        [
+          {
+            "node": "Upload media",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Upload media": {
+      "main": [
+        [
+          {
+            "node": "Re-assemble slides",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create a post": {
+      "main": [
+        []
+      ]
+    },
+    "DeepSeek Chat Model": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Basic LLM Chain",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Latest post": {
+      "main": [
+        [
+          {
+            "node": "Basic LLM Chain",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Basic LLM Chain": {
+      "main": [
+        [
+          {
+            "node": "Parse slides JSON",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse slides JSON": {
+      "main": [
+        [
+          {
+            "node": "Split into slides",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split into slides": {
+      "main": [
+        [
+          {
+            "node": "theme_color",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate media using AI model": {
+      "main": [
+        [
+          {
+            "node": "Download generated background",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Re-assemble slides": {
+      "main": [
+        [
+          {
+            "node": "Generate text carousel PDF",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate text carousel PDF": {
+      "main": [
+        [
+          {
+            "node": "Create a post",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "theme_color": {
+      "main": [
+        [
+          {
+            "node": "Generate media using AI model",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate",
+    "availableInMCP": false
+  },
+  "versionId": "6c394a30-d605-4244-bb79-24fe225b06c7",
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "id": "PLUSdT5qkKZrNMfX",
+  "tags": [
+    {
+      "updatedAt": "2026-06-02T08:57:53.950Z",
+      "createdAt": "2026-06-02T08:57:53.950Z",
+      "id": "8rcWTt5CS63KQzEw",
+      "name": "socialmedia"
+    },
+    {
+      "updatedAt": "2026-06-02T09:01:25.831Z",
+      "createdAt": "2026-06-02T09:01:25.831Z",
+      "id": "8xBogo6fq3RQfLdT",
+      "name": "autopost"
+    },
+    {
+      "updatedAt": "2026-06-02T08:57:45.531Z",
+      "createdAt": "2026-06-02T08:57:45.531Z",
+      "id": "E2V7Vb6mVjkhPHEs",
+      "name": "blog"
+    },
+    {
+      "updatedAt": "2026-06-02T09:01:40.639Z",
+      "createdAt": "2026-06-02T09:01:40.639Z",
+      "id": "ESvKanJ6OwKaH6u4",
+      "name": "posta"
+    },
+    {
+      "updatedAt": "2026-06-04T10:18:35.324Z",
+      "createdAt": "2026-06-04T10:18:35.324Z",
+      "id": "YoazfSGedHuWQz2y",
+      "name": "linkedin"
+    }
+  ]
+}

--- a/workflows/Posta/Posta_Blog_to_Social_Media_Scheduled.json
+++ b/workflows/Posta/Posta_Blog_to_Social_Media_Scheduled.json
@@ -1,0 +1,404 @@
+{
+  "name": "Blog post shared to social media",
+  "nodes": [
+    {
+      "parameters": {},
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -240,
+        64
+      ],
+      "id": "f15e7ec2-775f-4e6b-a455-88ae68553636",
+      "name": "When clicking ‘Execute workflow’"
+    },
+    {
+      "parameters": {
+        "url": "https://getposta.app/feed.xml",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.rssFeedRead",
+      "typeVersion": 1.2,
+      "position": [
+        64,
+        16
+      ],
+      "id": "82974bd0-595d-405a-926d-6ee4ad07def8",
+      "name": "RSS Read",
+      "notes": "Add the link to the RSS feed"
+    },
+    {
+      "parameters": {
+        "content": "Add the link to the RSS feed, in this example we use the blog feed from getposta.app (https://getposta.app/feed.xml)",
+        "height": 112,
+        "width": 288
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -32,
+        -112
+      ],
+      "id": "1456cb3d-6560-46f2-985a-07d67bd217c4",
+      "name": "Sticky Note"
+    },
+    {
+      "parameters": {
+        "socialAccountIds": "35",
+        "caption": "={{ $json.content }}",
+        "additionalFields": {
+          "hashtags": "={{ $json.categories[0] }}{{ $json.categories[2] }}",
+          "mediaIds": "={{ $('Upload media').item.json.media.id }}"
+        },
+        "platformConfigurations": {
+          "linkedin": {
+            "documentTitle": "={{ $json.title }}"
+          }
+        }
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        1312,
+        -16
+      ],
+      "id": "a95327e0-ed2b-4154-bf73-e9ec55fb8af3",
+      "name": "Create a post",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "socialAccount"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        544,
+        464
+      ],
+      "id": "969f72c4-be11-45c0-a9a5-3e37f036bff9",
+      "name": "Get many social accounts",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "You need to tell the workflow where to post - call this to get a list of connected social accounts. You need to take the id value and feed into the next step. IDs are preserved in Posta until you delete the connected account. To sign-up and connect social accounts, visit https://www.getposta.app (14 days free, no credit card required)",
+        "height": 240,
+        "color": 3
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        480,
+        640
+      ],
+      "id": "30f5f96f-35c5-47b8-94db-a104d4b63d78",
+      "name": "Sticky Note1"
+    },
+    {
+      "parameters": {
+        "content": "You need a token to use the Posta functions. Get one at https://www.getposta.app (14 days free, no credit card required)",
+        "height": 128,
+        "color": 3
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -368,
+        -128
+      ],
+      "id": "454af41e-776b-4fe3-ad36-8f1a04f8ce1a",
+      "name": "Sticky Note2"
+    },
+    {
+      "parameters": {
+        "content": "## Blog post → social media\n\n**Who it's for:** anyone with a blog who wants every new post announced across their socials automatically.\n**What it does:** reads your blog RSS feed and schedules a social post (with the article image) to your connected accounts via Posta.\n\n**How it works:**\n1. Read the blog RSS feed.\n2. Get your connected social accounts.\n3. Download the article image and upload it to Posta (auto-scaled per platform).\n4. Combine image + text, create the post, and schedule it.\n\n**Setup:** add your Posta API token credential, set your RSS feed URL, and pick the account IDs to post to. Sign up at https://www.getposta.app (14 days free, no credit card).",
+        "height": 240,
+        "color": 5
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -368,
+        -368
+      ],
+      "id": "43e47287-f693-464a-861d-b227e81872ec",
+      "name": "Sticky Note3"
+    },
+    {
+      "parameters": {
+        "content": "In the create post you need to set at least one social account id (from \"get many social accounts\"), caption and optionally tags. For each supported social media account type, you can also set platform specific attributes like visibility etc. You can also add media ids to upload images and videos. Images and videos are scaled by Posta for each platform (9:16 for TikTok for example). Posta uses facial recognition to try to crop media if faces are present. ",
+        "height": 304
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1312,
+        -352
+      ],
+      "id": "feb61689-0b63-4728-8646-5f7635d2b471",
+      "name": "Sticky Note4"
+    },
+    {
+      "parameters": {
+        "resource": "media"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        608,
+        -160
+      ],
+      "id": "19be590a-a990-4217-be2f-363b87b93702",
+      "name": "Upload media",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.enclosure.url }}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "file"
+            }
+          }
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        368,
+        -160
+      ],
+      "id": "3dae8df0-04bb-4da6-b3d3-d0381db68ba2",
+      "name": "Download article image"
+    },
+    {
+      "parameters": {
+        "content": "Add the URL for the image. Then options -> response -> then \"response format -> file\" and put the output in field \"data\". This loads the image into the \"data\" field for further processing. "
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        304,
+        -336
+      ],
+      "id": "5da0686e-7763-46a8-9b90-667b31d84b6c",
+      "name": "Sticky Note5"
+    },
+    {
+      "parameters": {
+        "content": "This upload the contents of the \"data\" field from the precious node to the Posta platform and image processing starts (scaling for the different platforms). This also works for videos."
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        608,
+        -336
+      ],
+      "id": "3181fdf6-ac51-4492-a804-4c9db005dcac",
+      "name": "Sticky Note6"
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineByPosition",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        992,
+        -16
+      ],
+      "id": "c458d1d9-6d69-44fa-b2b4-48153513cc9f",
+      "name": "Combine image + article text"
+    },
+    {
+      "parameters": {
+        "content": "We merge the outputs from upload media (delivers the media id) and the RSS Read (delivers the text). Mode \"combine\" and combine by \"position\"."
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        944,
+        -224
+      ],
+      "id": "10dfa4ad-2010-4067-a5a9-785b9f49bf44",
+      "name": "Sticky Note7"
+    },
+    {
+      "parameters": {
+        "content": "The post is created by default as \"draft\" in the Posta backend - from this point you can publish it in the next step, or schedule it for later."
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1392,
+        128
+      ],
+      "id": "b5912958-60e5-4e1c-a6e9-a73621692cb6",
+      "name": "Sticky Note8"
+    },
+    {
+      "parameters": {
+        "operation": "schedule",
+        "postId": "={{ $json.id }}",
+        "scheduledAt": "2026-06-30T00:00:00"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        1696,
+        -16
+      ],
+      "id": "af95f8ef-7688-40dd-acaa-8559f1b73978",
+      "name": "Schedule a post",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "In this example we schedule the post for June 30 2026."
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1792,
+        -176
+      ],
+      "id": "e70a3f3d-d4c2-46ae-8919-0e2ebc66b53c",
+      "name": "Sticky Note9"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "When clicking ‘Execute workflow’": {
+      "main": [
+        [
+          {
+            "node": "Get many social accounts",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "RSS Read",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "RSS Read": {
+      "main": [
+        [
+          {
+            "node": "Download article image",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Combine image + article text",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Download article image": {
+      "main": [
+        [
+          {
+            "node": "Upload media",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Upload media": {
+      "main": [
+        [
+          {
+            "node": "Combine image + article text",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create a post": {
+      "main": [
+        [
+          {
+            "node": "Schedule a post",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Combine image + article text": {
+      "main": [
+        [
+          {
+            "node": "Create a post",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate"
+  },
+  "versionId": "135fcc44-1c2a-4684-a98d-2bdfaa0dd460",
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "id": "u2Xp2NaAQa5wkE9H",
+  "tags": [
+    {
+      "updatedAt": "2026-06-02T08:57:53.950Z",
+      "createdAt": "2026-06-02T08:57:53.950Z",
+      "id": "8rcWTt5CS63KQzEw",
+      "name": "socialmedia"
+    },
+    {
+      "updatedAt": "2026-06-02T09:01:25.831Z",
+      "createdAt": "2026-06-02T09:01:25.831Z",
+      "id": "8xBogo6fq3RQfLdT",
+      "name": "autopost"
+    },
+    {
+      "updatedAt": "2026-06-02T08:57:45.531Z",
+      "createdAt": "2026-06-02T08:57:45.531Z",
+      "id": "E2V7Vb6mVjkhPHEs",
+      "name": "blog"
+    },
+    {
+      "updatedAt": "2026-06-02T09:01:40.639Z",
+      "createdAt": "2026-06-02T09:01:40.639Z",
+      "id": "ESvKanJ6OwKaH6u4",
+      "name": "posta"
+    }
+  ]
+}

--- a/workflows/Posta/Posta_Product_Launch_Campaign_Scheduled.json
+++ b/workflows/Posta/Posta_Product_Launch_Campaign_Scheduled.json
@@ -1,0 +1,734 @@
+{
+  "name": "E-commerce product launch campaign",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## 5-day product launch campaign\n\n**Who it's for:** e-commerce teams launching a product across every channel.\n**What it does:** turns one product into a 5-day, multi-platform campaign with per-platform captions, scheduled via Posta.\n\n**How it works:**\n1. Fetch the product and its image.\n2. Get active accounts; keep one post per platform type.\n3. DeepSeek writes captions + tags per platform.\n4. Expand across 5 days and schedule a post for every account.\n\n**Setup:** add your Posta and DeepSeek (or any LLM) credentials. Sign up at https://www.getposta.app (14 days free, no credit card).",
+        "height": 240,
+        "color": 5
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -944,
+        -512
+      ],
+      "id": "4b7e66ec-9823-4a8c-99be-45c4a9f00474",
+      "name": "Sticky Note"
+    },
+    {
+      "parameters": {
+        "content": "You need a token to use the Posta functions. Get one at https://www.getposta.app (14 days free, no credit card required)\n\nYou also need an API key for an LLM, in this example we use DeepSeek.",
+        "height": 208,
+        "color": 3
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -944,
+        -256
+      ],
+      "id": "6a4cf8ec-f7a3-461c-9b5b-4714cdb3357f",
+      "name": "Sticky Note1"
+    },
+    {
+      "parameters": {},
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -576,
+        -224
+      ],
+      "id": "71e9da98-d459-41ff-9796-09e645ad6de8",
+      "name": "When clicking ‘Execute workflow’"
+    },
+    {
+      "parameters": {
+        "url": "https://fakestoreapi.com/products/1",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        -352,
+        -224
+      ],
+      "id": "95935938-a652-4bff-b5ec-5ef6801aa73c",
+      "name": "Fetch product"
+    },
+    {
+      "parameters": {
+        "content": "Start by polling the product (or use a webhook to let the system tell you what is new)",
+        "height": 352
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -432,
+        -384
+      ],
+      "id": "946cd4d8-312f-40c7-9b7f-d6debee698f4",
+      "name": "Sticky Note2"
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "=Write ONE {{ $json.platform }} caption for day {{ $json.day }} of a 5-day campaign\n  for \"{{ $json.title }}\" ({{ $json.description }}, ${{ $json.price }}).\n  End with 3–5 relevant hashtags. Return only the caption — no preamble.",
+        "messages": {
+          "messageValues": [
+            {
+              "message": "You are the best social media marketing expert in the world."
+            }
+          ]
+        },
+        "batching": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.chainLlm",
+      "typeVersion": 1.9,
+      "position": [
+        1152,
+        -208
+      ],
+      "id": "dce15ba8-975c-46f6-ac1c-2017bc9b480a",
+      "name": "Basic LLM Chain"
+    },
+    {
+      "parameters": {
+        "model": "deepseek-v4-pro",
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.lmChatDeepSeek",
+      "typeVersion": 1,
+      "position": [
+        1152,
+        48
+      ],
+      "id": "044989a2-8cf9-4865-a50a-51b2c58f72e8",
+      "name": "DeepSeek Chat Model",
+      "credentials": {
+        "deepSeekApi": {
+          "name": "DeepSeek account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "socialAccount"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        -352,
+        80
+      ],
+      "id": "23da3937-9a5c-40d3-b871-82fbfd291199",
+      "name": "Get many social accounts",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "Get all connected social accounts connected in the Posta app.",
+        "height": 304,
+        "width": 288
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -448,
+        0
+      ],
+      "id": "963dfd8b-f036-46ba-8959-9b6b4ef7048c",
+      "name": "Sticky Note3"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 3
+          },
+          "conditions": [
+            {
+              "id": "965b8dcb-cbbf-4a09-be7d-91190b09681e",
+              "leftValue": "={{ $json.isActive }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "0650294d-1302-4d4b-97ed-14826faddb9a",
+              "leftValue": "",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "equals",
+                "name": "filter.operator.equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2.3,
+      "position": [
+        -64,
+        80
+      ],
+      "id": "886cbb0c-d24a-4344-a2d7-e9652ba78d56",
+      "name": "Keep active accounts"
+    },
+    {
+      "parameters": {
+        "content": "We select all active social accounts",
+        "height": 304
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -128,
+        0
+      ],
+      "id": "16eb4ca4-e0b6-4016-9563-c5db72b11a4a",
+      "name": "Sticky Note4"
+    },
+    {
+      "parameters": {
+        "compare": "selectedFields",
+        "fieldsToCompare": "platform",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.removeDuplicates",
+      "typeVersion": 2,
+      "position": [
+        272,
+        160
+      ],
+      "id": "40308f8a-15ff-4eaf-a450-2f8db59ea539",
+      "name": "One post per platform"
+    },
+    {
+      "parameters": {
+        "content": "Remove duplicates from platform. We want to create a single post for each platform type (one for TikTok, once for LinkedIn etc), not one post for each account. ",
+        "height": 304,
+        "width": 224
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        208,
+        0
+      ],
+      "id": "9ffed604-3103-42be-8523-f723ab408ad7",
+      "name": "Sticky Note5"
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineAll",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        592,
+        -208
+      ],
+      "id": "a12e72fe-1ba7-4895-b419-097d34ca44ed",
+      "name": "Combine product + platforms"
+    },
+    {
+      "parameters": {
+        "content": "Now we have the product description for each platform type, ready to send to the LLM.",
+        "height": 288
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        528,
+        -336
+      ],
+      "id": "b7c416ea-3447-4110-b08b-801598504008",
+      "name": "Sticky Note6"
+    },
+    {
+      "parameters": {
+        "content": "We want to create posts for each day over the next 5 days",
+        "height": 288
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        784,
+        -336
+      ],
+      "id": "70d7fab0-1cd6-4961-89e5-c36cb322819e",
+      "name": "Sticky Note8"
+    },
+    {
+      "parameters": {
+        "jsCode": "const ctx = $('Expand to days').all();\n  return $input.all().map((item, i) => {\n    const day = ctx[i].json.day;\n    return {\n      json: {\n        platform: ctx[i].json.platform,\n        day,\n        caption: item.json.text,\n        mediaId:  ctx[i].json.mediaId,\n        scheduledAt: $now\n          .plus({ days: day })                                  // day 1 = tomorrow, day 5 = +5\n          .set({ hour: 9, minute: 0, second: 0, millisecond: 0 }) // post at 09:00\n          .toUTC()\n          .toISO(),                                             // strict UTC ISO the API wants\n      },\n    };\n  });"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1504,
+        -208
+      ],
+      "id": "70a87504-d83b-4a22-b4d3-ada5dcc09b30",
+      "name": "Parse LLM captions"
+    },
+    {
+      "parameters": {
+        "jsCode": "return $input.all().flatMap(i =>\n    [1,2,3,4,5].map(day => ({ json: { ...i.json, day } }))\n  );"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        848,
+        -208
+      ],
+      "id": "b12bdda8-009d-4a53-bfca-d213eb8153b3",
+      "name": "Expand to days"
+    },
+    {
+      "parameters": {
+        "content": "Add the platforms, the schedule data",
+        "height": 304
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1424,
+        -320
+      ],
+      "id": "f3cd15f1-e463-49ff-9ae8-fca7c2746d76",
+      "name": "Sticky Note9"
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "fieldsToMatchString": "platform",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        1824,
+        16
+      ],
+      "id": "1447b440-295f-4586-b626-04641c2979bb",
+      "name": "Merge captions per account"
+    },
+    {
+      "parameters": {
+        "content": "Merge on platform, we create the same post for each instance of a platform, so if you have multiple TikTok (for example) accounts, each will get a post. ",
+        "height": 288
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1760,
+        -96
+      ],
+      "id": "d6e2b680-014a-4953-b839-070c207d9d25",
+      "name": "Sticky Note10"
+    },
+    {
+      "parameters": {
+        "resource": "post",
+        "operation": "create",
+        "socialAccountIds": "= {{ $json.id }}",
+        "caption": "={{ $json.caption }}",
+        "additionalFields": {
+          "mediaIds": "= {{ $json.mediaId }}",
+          "isDraft": false
+        },
+        "platformConfigurations": {}
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        2112,
+        16
+      ],
+      "id": "60fbaf61-4f56-4607-b851-a0a1f10ef977",
+      "name": "Create a post",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "Create posts with account ids, captions, schedules. Draft is OFF and they will be created by the Posta app for future posting.",
+        "height": 288
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2032,
+        -96
+      ],
+      "id": "8d3cacbf-fb3d-49ed-81b1-032b7986b522",
+      "name": "Sticky Note11"
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.image }}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "file"
+            }
+          }
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        -96,
+        -224
+      ],
+      "id": "d1f45c2b-c557-48da-b10a-708491d81c70",
+      "name": "Download product image"
+    },
+    {
+      "parameters": {
+        "resource": "media"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        80,
+        -224
+      ],
+      "id": "b8d6ab49-2385-48fb-b7a3-b69bb6a95797",
+      "name": "Upload media",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "c5a46e5b-3a92-42b8-bf14-d473fee0281c",
+              "name": "mediaId",
+              "value": "={{ $json.media.id }}",
+              "type": "string"
+            },
+            {
+              "id": "7addd58f-f2da-4dbb-8865-cfaa061de77d",
+              "name": "title",
+              "value": "={{ $('Fetch product').first().json.title }}",
+              "type": "string"
+            },
+            {
+              "id": "ddbf23e7-facd-4b29-8406-d9c39d4d8f20",
+              "name": "description",
+              "value": "={{ $('Fetch product').first().json.description }}",
+              "type": "string"
+            },
+            {
+              "id": "ad5022e7-ddf4-48c6-9aa0-6f80b9cc5f31",
+              "name": "price",
+              "value": "={{ $('Fetch product').first().json.price }}",
+              "type": "string"
+            },
+            {
+              "id": "775e372b-c120-4ab2-ac72-c23527ca7dc2",
+              "name": "image",
+              "value": "={{ $('Fetch product').first().json.image }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        288,
+        -224
+      ],
+      "id": "205d4483-bb45-4bd1-bcf7-525fd22f56eb",
+      "name": "Attach product media id"
+    },
+    {
+      "parameters": {
+        "content": "Get the image for the product",
+        "height": 352,
+        "width": 160
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -128,
+        -384
+      ],
+      "id": "f1831e45-404f-4ec2-9c57-ec0209745703",
+      "name": "Sticky Note12"
+    },
+    {
+      "parameters": {
+        "content": "Upload the media to the Posta app, the platform will scale the image to fit to all social platforms. It uses facial recognition to try to crop the image if faces are present.",
+        "height": 352,
+        "width": 182
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        48,
+        -384
+      ],
+      "id": "4cdb4b84-7e2d-496a-bcbb-d9782097383f",
+      "name": "Sticky Note13"
+    },
+    {
+      "parameters": {
+        "content": "We add the data from the first request since the upload media only returns the media id from the Posta platform.",
+        "height": 352,
+        "width": 160
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        256,
+        -384
+      ],
+      "id": "b3d6bfa5-f655-4a59-a713-72cf3ee0e132",
+      "name": "Sticky Note14"
+    },
+    {
+      "parameters": {
+        "content": "Post are now created, either in \"draft\" or scheduled depending on the parameters in the last node. Now you can continue by publishing or editing the posts. "
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2384,
+        -16
+      ],
+      "id": "dd52393a-153f-4d1f-9024-c2d0a72e5120",
+      "name": "Sticky Note7"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "When clicking ‘Execute workflow’": {
+      "main": [
+        [
+          {
+            "node": "Fetch product",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Get many social accounts",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "DeepSeek Chat Model": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Basic LLM Chain",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch product": {
+      "main": [
+        [
+          {
+            "node": "Download product image",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get many social accounts": {
+      "main": [
+        [
+          {
+            "node": "Keep active accounts",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keep active accounts": {
+      "main": [
+        [
+          {
+            "node": "One post per platform",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "One post per platform": {
+      "main": [
+        [
+          {
+            "node": "Combine product + platforms",
+            "type": "main",
+            "index": 1
+          },
+          {
+            "node": "Merge captions per account",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Combine product + platforms": {
+      "main": [
+        [
+          {
+            "node": "Expand to days",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Basic LLM Chain": {
+      "main": [
+        [
+          {
+            "node": "Parse LLM captions",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Expand to days": {
+      "main": [
+        [
+          {
+            "node": "Basic LLM Chain",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse LLM captions": {
+      "main": [
+        [
+          {
+            "node": "Merge captions per account",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge captions per account": {
+      "main": [
+        [
+          {
+            "node": "Create a post",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download product image": {
+      "main": [
+        [
+          {
+            "node": "Upload media",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Upload media": {
+      "main": [
+        [
+          {
+            "node": "Attach product media id",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Attach product media id": {
+      "main": [
+        [
+          {
+            "node": "Combine product + platforms",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate"
+  },
+  "versionId": "4ddba110-25ff-4606-8e61-cf21aea05740",
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "id": "ZIzfh6sIe4ToAqeC",
+  "tags": [
+    {
+      "updatedAt": "2026-06-02T09:01:25.831Z",
+      "createdAt": "2026-06-02T09:01:25.831Z",
+      "id": "8xBogo6fq3RQfLdT",
+      "name": "autopost"
+    },
+    {
+      "updatedAt": "2026-06-02T09:01:40.639Z",
+      "createdAt": "2026-06-02T09:01:40.639Z",
+      "id": "ESvKanJ6OwKaH6u4",
+      "name": "posta"
+    },
+    {
+      "updatedAt": "2026-06-03T12:31:06.730Z",
+      "createdAt": "2026-06-03T12:31:06.730Z",
+      "id": "Yj8jMnpGLDXpmAr4",
+      "name": "e-commerce"
+    },
+    {
+      "updatedAt": "2026-06-03T12:31:12.744Z",
+      "createdAt": "2026-06-03T12:31:12.744Z",
+      "id": "ZG1V0O463Dgrj7Gj",
+      "name": "product"
+    }
+  ]
+}

--- a/workflows/Posta/Posta_YouTube_to_Social_Media_Triggered.json
+++ b/workflows/Posta/Posta_YouTube_to_Social_Media_Triggered.json
@@ -1,0 +1,744 @@
+{
+  "name": "YouTube video to social media promotion",
+  "nodes": [
+    {
+      "parameters": {},
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -240,
+        64
+      ],
+      "id": "c7c80056-b1b1-4e79-b96d-9a2c751d4a3a",
+      "name": "When clicking ‘Execute workflow’"
+    },
+    {
+      "parameters": {
+        "socialAccountIds": "= {{ $json.id.toString() }}",
+        "caption": "={{ $json.caption }}{{ $json.url }}",
+        "additionalFields": {
+          "mediaIds": "={{ $('Upload media').item.json.media.id }}",
+          "isDraft": true
+        },
+        "platformConfigurations": {
+          "linkedin": {
+            "documentTitle": "={{ $json.title }}"
+          }
+        }
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        2992,
+        32
+      ],
+      "id": "e11a8e5b-77d2-444a-a04b-5f074f5fa658",
+      "name": "Create a post",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "socialAccount"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        544,
+        688
+      ],
+      "id": "935a6f34-9170-4830-90dc-d2764530b323",
+      "name": "Get many social accounts",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "You need to tell the workflow where to post - call this to get a list of connected social accounts. To sign-up and connect social accounts, visit https://www.getposta.app (14 days free, no credit card required)",
+        "height": 480,
+        "color": 3
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        480,
+        400
+      ],
+      "id": "ce7cb33c-f3fb-4674-8095-5b078920aa47",
+      "name": "Sticky Note1"
+    },
+    {
+      "parameters": {
+        "content": "You need a token to use the Posta functions. Get one at https://www.getposta.app (14 days free, no credit card required)",
+        "height": 128,
+        "color": 3
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -368,
+        -128
+      ],
+      "id": "a75cc4bb-62bd-4011-8f6b-3393355c9548",
+      "name": "Sticky Note2"
+    },
+    {
+      "parameters": {
+        "content": "## YouTube video → social media\n\n**Who it's for:** creators who want to promote each new video everywhere automatically.\n**What it does:** reads your YouTube feed, grabs the latest video + thumbnail, and drafts promo posts for every platform via Posta.\n\n**How it works:**\n1. Download the YouTube channel feed and parse the latest video.\n2. Upload the thumbnail to Posta (auto-scaled per platform).\n3. Get active accounts; keep one post per platform type.\n4. DeepSeek writes a caption per platform; create draft posts to review.\n\n**Setup:** add your Posta and DeepSeek credentials, and set your channel feed URL. Sign up at https://www.getposta.app (14 days free, no credit card).",
+        "height": 240,
+        "color": 5
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -368,
+        -384
+      ],
+      "id": "d8b976b6-bae7-43c3-ae00-6f6859ac7e2f",
+      "name": "Sticky Note3"
+    },
+    {
+      "parameters": {
+        "resource": "media"
+      },
+      "type": "n8n-nodes-posta.posta",
+      "typeVersion": 1,
+      "position": [
+        1024,
+        -32
+      ],
+      "id": "d0c501b4-01f4-4066-a940-fe751214f6ca",
+      "name": "Upload media",
+      "credentials": {
+        "postaApi": {
+          "name": "Posta account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.thumbnail }}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "file"
+            }
+          }
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        768,
+        -32
+      ],
+      "id": "6518497f-ad13-4b04-8208-bdedc0c6378c",
+      "name": "Download thumbnail"
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineByPosition",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        1360,
+        32
+      ],
+      "id": "b35f43aa-662f-4d34-923c-dd9bee67fb6e",
+      "name": "Combine thumbnail + video data"
+    },
+    {
+      "parameters": {
+        "content": "We merge the outputs from upload media (delivers the media id) and the structureed json. Mode \"combine\" and combine by \"position\".",
+        "height": 336
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1264,
+        -96
+      ],
+      "id": "d9965a14-7a44-44da-a682-86368f5ff4ba",
+      "name": "Sticky Note7"
+    },
+    {
+      "parameters": {
+        "content": "The post is created by default as \"draft\" in the Posta backend - from this point you can publish it in the next step, or schedule it for later.",
+        "height": 320
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2944,
+        -96
+      ],
+      "id": "fc8d4240-17e3-48a0-9da3-cd4d4817fda5",
+      "name": "Sticky Note8"
+    },
+    {
+      "parameters": {
+        "content": "Download from the RSS endpoint. n8n strips a lot of data, so use HTTP Request",
+        "height": 336
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -16,
+        -96
+      ],
+      "id": "864c538f-4734-47ec-a1c8-af516a85788b",
+      "name": "Sticky Note10"
+    },
+    {
+      "parameters": {
+        "content": "Create json from XML, save it into \"data\"",
+        "height": 336
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        224,
+        -96
+      ],
+      "id": "e3f132c8-47c5-457f-9770-898266739d3b",
+      "name": "Sticky Note11"
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "n8n-nodes-base.xml",
+      "typeVersion": 1,
+      "position": [
+        288,
+        96
+      ],
+      "id": "17c8f927-4708-4b2c-a91f-13bea3a82dea",
+      "name": "Parse feed XML"
+    },
+    {
+      "parameters": {
+        "url": "https://www.youtube.com/feeds/videos.xml?channel_id=UC6vsUGbvtdWizEn1GZDT1ZQ",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "text"
+            }
+          }
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        48,
+        16
+      ],
+      "id": "104ab147-429a-42a1-a26e-250d6a4d6e64",
+      "name": "Download YouTube feed"
+    },
+    {
+      "parameters": {
+        "jsCode": "const root = $input.first().json;\n  const entries = [].concat(root.feed?.entry ?? []).slice(0, 1);  // latest only\n  return entries.map(e => {\n    const g = e['media:group'] ?? {};\n    return { json: {\n      videoId:     e['yt:videoId'],\n      title:       typeof e.title === 'string' ? e.title : e.title?._,\n      description: g['media:description'],\n      thumbnail:   g['media:thumbnail']?.url,\n      url:         e.link?.href ?? e.link?.url,\n      published:   e.published,\n    }};\n  });"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        544,
+        80
+      ],
+      "id": "a0247b4b-55c4-40a4-8af4-fe76eda01adc",
+      "name": "Latest video"
+    },
+    {
+      "parameters": {
+        "content": "Create structured json. **IMPORTANT:** we limit to the last video here: const entries = [].concat(root.feed?.entry ?? []).slice(0, 1);  // latest only \nChange the way you see fit.",
+        "height": 336
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        480,
+        -96
+      ],
+      "id": "cd80c088-de0f-41d5-a13b-531a0ff7bde9",
+      "name": "Sticky Note12"
+    },
+    {
+      "parameters": {
+        "content": "Download the Youtube video thumbnails",
+        "height": 336
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        720,
+        -96
+      ],
+      "id": "07b6219f-3fb6-44ef-b562-b70127e94e3a",
+      "name": "Sticky Note13"
+    },
+    {
+      "parameters": {
+        "content": "Upload the thumbnails to the Posta app.",
+        "height": 336
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        976,
+        -96
+      ],
+      "id": "a590913b-ff1a-402d-952f-c33769aacb86",
+      "name": "Sticky Note14"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 3
+          },
+          "conditions": [
+            {
+              "id": "965b8dcb-cbbf-4a09-be7d-91190b09681e",
+              "leftValue": "={{ $json.isActive }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            },
+            {
+              "id": "0650294d-1302-4d4b-97ed-14826faddb9a",
+              "leftValue": "",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "equals",
+                "name": "filter.operator.equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2.3,
+      "position": [
+        784,
+        544
+      ],
+      "id": "214f8125-bd77-40d0-b2b6-5d83dc672e5a",
+      "name": "Keep active accounts"
+    },
+    {
+      "parameters": {
+        "content": "We select all active social accounts",
+        "height": 480
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        736,
+        400
+      ],
+      "id": "6bf187a4-26fc-4d4f-b94e-5c00c0c01fc4",
+      "name": "Sticky Note15"
+    },
+    {
+      "parameters": {
+        "compare": "selectedFields",
+        "fieldsToCompare": "platform",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.removeDuplicates",
+      "typeVersion": 2,
+      "position": [
+        1056,
+        544
+      ],
+      "id": "d2ba6b8c-5b56-4235-8017-4638ef8dd54d",
+      "name": "One post per platform"
+    },
+    {
+      "parameters": {
+        "content": "Remove duplicates from platform. We want to create a single post for each platform type (one for TikTok, once for LinkedIn etc), not one post for each account. ",
+        "height": 480,
+        "width": 224
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        992,
+        400
+      ],
+      "id": "dafaf967-c847-4882-a124-7bbf199c3589",
+      "name": "Sticky Note16"
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineAll",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        1600,
+        32
+      ],
+      "id": "4ab71d12-58c4-4ff6-a09c-7335ed70b9d2",
+      "name": "Combine video + platforms"
+    },
+    {
+      "parameters": {
+        "content": "Create all possible combinations - this gives a list of post data for each account type that was delivered from upstream",
+        "height": 336,
+        "width": 288
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        1552,
+        -96
+      ],
+      "id": "11c1f549-54c5-4f6d-a999-12e456f8b704",
+      "name": "Sticky Note17"
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "=Write a {{ $json.platform }} post promoting this YouTube video:\n  Title: {{ $json.title }}\n  Description: {{ $json.description }}\n  Tailor it to {{ $json.platform }} (tone, length, hashtags). Return only the caption.",
+        "messages": {
+          "messageValues": [
+            {
+              "message": "You are the best social media marketing expert in the world."
+            }
+          ]
+        },
+        "batching": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.chainLlm",
+      "typeVersion": 1.9,
+      "position": [
+        2000,
+        32
+      ],
+      "id": "fa7c6508-5890-457d-a86a-543d1da3346f",
+      "name": "Basic LLM Chain"
+    },
+    {
+      "parameters": {
+        "model": "deepseek-v4-pro",
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.lmChatDeepSeek",
+      "typeVersion": 1,
+      "position": [
+        2032,
+        240
+      ],
+      "id": "cc716326-2cb9-491a-9adf-b09a21f00d87",
+      "name": "DeepSeek Chat Model",
+      "credentials": {
+        "deepSeekApi": {
+          "name": "DeepSeek account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const ctx = $('Combine video + platforms').all();   // ← your cross-join node's name\n  return $input.all().map((item, i) => {\n    const videoUrl = `https://www.youtube.com/watch?v=${ctx[i].json.videoId}`;\n    return {\n      json: {\n        platform: ctx[i].json.platform,\n        videoId:  ctx[i].json.videoId,\n        mediaId:  ctx[i].json.mediaId,\n        url:      videoUrl,\n        caption:  `${item.json.text}\\n\\n▶️  Watch: ${videoUrl}`,\n      },\n    };\n  });"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2352,
+        32
+      ],
+      "id": "4099d081-9007-4aba-a633-352acb376558",
+      "name": "Tag captions with platform"
+    },
+    {
+      "parameters": {
+        "content": "The LLM gives only text, so lets add platform so we know what posts to create",
+        "height": 320
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2304,
+        -96
+      ],
+      "id": "3ae1905f-f3d9-472e-b1a1-9076ab878949",
+      "name": "Sticky Note4"
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "fieldsToMatchString": "platform",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        2688,
+        32
+      ],
+      "id": "2989b183-7287-457c-82f8-0c879465e8af",
+      "name": "Post per active account"
+    },
+    {
+      "parameters": {
+        "content": "Now merge the posts with each active account - we create a post for each account. ",
+        "height": 320
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2656,
+        -96
+      ],
+      "id": "bbcbd1b7-7103-4bfb-9b37-680a767a1d81",
+      "name": "Sticky Note9"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "When clicking ‘Execute workflow’": {
+      "main": [
+        [
+          {
+            "node": "Get many social accounts",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Download YouTube feed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download thumbnail": {
+      "main": [
+        [
+          {
+            "node": "Upload media",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Upload media": {
+      "main": [
+        [
+          {
+            "node": "Combine thumbnail + video data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create a post": {
+      "main": [
+        []
+      ]
+    },
+    "Combine thumbnail + video data": {
+      "main": [
+        [
+          {
+            "node": "Combine video + platforms",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download YouTube feed": {
+      "main": [
+        [
+          {
+            "node": "Parse feed XML",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse feed XML": {
+      "main": [
+        [
+          {
+            "node": "Latest video",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Latest video": {
+      "main": [
+        [
+          {
+            "node": "Download thumbnail",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Combine thumbnail + video data",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Get many social accounts": {
+      "main": [
+        [
+          {
+            "node": "Keep active accounts",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keep active accounts": {
+      "main": [
+        [
+          {
+            "node": "One post per platform",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Post per active account",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "One post per platform": {
+      "main": [
+        [
+          {
+            "node": "Combine video + platforms",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "DeepSeek Chat Model": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Basic LLM Chain",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Combine video + platforms": {
+      "main": [
+        [
+          {
+            "node": "Basic LLM Chain",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Basic LLM Chain": {
+      "main": [
+        [
+          {
+            "node": "Tag captions with platform",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Tag captions with platform": {
+      "main": [
+        [
+          {
+            "node": "Post per active account",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Post per active account": {
+      "main": [
+        [
+          {
+            "node": "Create a post",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate",
+    "availableInMCP": false
+  },
+  "versionId": "9fe8204a-40c1-4ddf-af46-b5de082f157f",
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "id": "4SD4jWtZQmj48juh",
+  "tags": [
+    {
+      "updatedAt": "2026-06-02T08:57:53.950Z",
+      "createdAt": "2026-06-02T08:57:53.950Z",
+      "id": "8rcWTt5CS63KQzEw",
+      "name": "socialmedia"
+    },
+    {
+      "updatedAt": "2026-06-02T09:01:25.831Z",
+      "createdAt": "2026-06-02T09:01:25.831Z",
+      "id": "8xBogo6fq3RQfLdT",
+      "name": "autopost"
+    },
+    {
+      "updatedAt": "2026-06-02T08:57:45.531Z",
+      "createdAt": "2026-06-02T08:57:45.531Z",
+      "id": "E2V7Vb6mVjkhPHEs",
+      "name": "blog"
+    },
+    {
+      "updatedAt": "2026-06-02T09:01:40.639Z",
+      "createdAt": "2026-06-02T09:01:40.639Z",
+      "id": "ESvKanJ6OwKaH6u4",
+      "name": "posta"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `workflows/Posta/` folder with four original, MIT-licensed n8n templates built on the verified [`n8n-nodes-posta`](https://www.npmjs.com/package/n8n-nodes-posta) community node:

- **Blog → social media** — RSS feed → scheduled post with the article image across connected accounts
- **Blog → LinkedIn carousel** — article → 5-slide carousel PDF (DeepSeek text + fal.ai backgrounds, assembled by Posta)
- **Product launch campaign** — product → 5-day, multi-platform campaign with per-network AI captions
- **YouTube → social media** — latest video + thumbnail → AI promo drafts on every platform

All four:
- contain **no credentials or secrets** (referenced by name only; n8n prompts on import),
- have descriptive node names and in-canvas sticky-note documentation.

Source + guides: https://github.com/STGime/posta-n8n-workflows · https://getposta.app/workflows