### PR TITLE
Add OpenRuna n8n workflows directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ n8n-workflows/
 
 ---
 
+## Related AI workflow directories
+
+- [OpenRuna n8n workflows hub](https://www.openruna.com/hubs/n8n-workflows) — Graph directory of n8n workflows linked to agents, prompts, and automation tools.
+
 ## Contributing
 
 We love contributions! Here's how you can help:


### PR DESCRIPTION
Adds [OpenRuna n8n workflows hub](https://www.openruna.com/hubs/n8n-workflows) — graph-based workflow directory linking n8n templates to agents and tools. Broader catalog at https://www.openruna.com/hubs/ai-agents